### PR TITLE
Adds WEBP to image formats supported

### DIFF
--- a/src/Commands/Format.php
+++ b/src/Commands/Format.php
@@ -57,6 +57,7 @@ trait Format
             Formats::GIF_ALPHA,
             Formats::M3U8,
             Formats::F4M,
+            Formats::WEBP,
         ];
     }
 

--- a/src/Definitions/Formats.php
+++ b/src/Definitions/Formats.php
@@ -29,4 +29,5 @@ final class Formats
     const GIF           = 'gif';
     const GIF_ALPHA     = 'gif-alpha';
     const F4M           = 'f4m';
+    const WEBP          = 'webp';
 }


### PR DESCRIPTION
I know this works only because I've seen several Scene7 users using it,
e.g. this image I found in a search:

https://target.scene7.com/is/image/Target/GUEST_eb4cd632-33ec-4867-b824-e5529aa9632d?fmt=webp&wid=1400&qlt=80
shows

![Violet!](https://target.scene7.com/is/image/Target/GUEST_eb4cd632-33ec-4867-b824-e5529aa9632d?fmt=webp&wid=1400&qlt=80)